### PR TITLE
Add SKU export workflow and storage hub

### DIFF
--- a/app/src/main/java/com/sirim/scanner/data/AppContainer.kt
+++ b/app/src/main/java/com/sirim/scanner/data/AppContainer.kt
@@ -33,13 +33,15 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
         SirimDatabase.MIGRATION_1_2,
         SirimDatabase.MIGRATION_2_3,
         SirimDatabase.MIGRATION_3_4,
-        SirimDatabase.MIGRATION_4_5
+        SirimDatabase.MIGRATION_4_5,
+        SirimDatabase.MIGRATION_5_6
     ).build()
 
     override val repository: SirimRepository by lazy {
         SirimRepositoryImpl(
             sirimDao = database.sirimRecordDao(),
             skuDao = database.skuRecordDao(),
+            skuExportDao = database.skuExportDao(),
             context = context.applicationContext
         )
     }

--- a/app/src/main/java/com/sirim/scanner/data/db/SirimDatabase.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SirimDatabase.kt
@@ -6,13 +6,14 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [SirimRecord::class, SkuRecord::class],
-    version = 5,
+    entities = [SirimRecord::class, SkuRecord::class, SkuExportRecord::class],
+    version = 6,
     exportSchema = true
 )
 abstract class SirimDatabase : RoomDatabase() {
     abstract fun sirimRecordDao(): SirimRecordDao
     abstract fun skuRecordDao(): SkuRecordDao
+    abstract fun skuExportDao(): SkuExportDao
 
     companion object {
         val MIGRATION_1_2: Migration = object : Migration(1, 2) {
@@ -67,6 +68,21 @@ abstract class SirimDatabase : RoomDatabase() {
         val MIGRATION_4_5: Migration = object : Migration(4, 5) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE sku_records ADD COLUMN gallery_paths TEXT")
+            }
+        }
+
+        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS sku_exports (" +
+                        "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "uri TEXT NOT NULL, " +
+                        "file_name TEXT NOT NULL, " +
+                        "record_count INTEGER NOT NULL, " +
+                        "updated_at INTEGER NOT NULL" +
+                        ")"
+                )
+                database.execSQL("CREATE INDEX IF NOT EXISTS index_sku_exports_updated_at ON sku_exports(updated_at)")
             }
         }
     }

--- a/app/src/main/java/com/sirim/scanner/data/db/SkuExportDao.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SkuExportDao.kt
@@ -1,0 +1,16 @@
+package com.sirim.scanner.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SkuExportDao {
+    @Query("SELECT * FROM sku_exports ORDER BY updated_at DESC")
+    fun observeExports(): Flow<List<SkuExportRecord>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(record: SkuExportRecord): Long
+}

--- a/app/src/main/java/com/sirim/scanner/data/db/SkuExportRecord.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SkuExportRecord.kt
@@ -1,0 +1,19 @@
+package com.sirim.scanner.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "sku_exports")
+data class SkuExportRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "uri")
+    val uri: String,
+    @ColumnInfo(name = "file_name")
+    val fileName: String,
+    @ColumnInfo(name = "record_count")
+    val recordCount: Int,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/sirim/scanner/data/db/SkuRecordDao.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SkuRecordDao.kt
@@ -32,4 +32,7 @@ interface SkuRecordDao {
 
     @Delete
     suspend fun delete(record: SkuRecord)
+
+    @Query("SELECT * FROM sku_records ORDER BY created_at DESC")
+    suspend fun getAllRecordsOnce(): List<SkuRecord>
 }

--- a/app/src/main/java/com/sirim/scanner/data/db/StorageRecord.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/StorageRecord.kt
@@ -1,33 +1,31 @@
 package com.sirim.scanner.data.db
 
-// No change needed here. Your sealed class design is good.
 sealed class StorageRecord {
     abstract val id: Long
     abstract val createdAt: Long
+    abstract val title: String
+    abstract val description: String
 
-    data class Sirim(val record: SirimRecord) : StorageRecord() {
-        override val id: Long = record.id
-        override val createdAt: Long = record.createdAt
+    data class SirimDatabase(
+        val totalRecords: Int,
+        val lastUpdated: Long
+    ) : StorageRecord() {
+        override val id: Long = 1
+        override val createdAt: Long = lastUpdated
+        override val title: String = "SIRIM Records"
+        override val description: String = if (totalRecords == 1) {
+            "1 record stored"
+        } else {
+            "$totalRecords records stored"
+        }
     }
 
-    data class Sku(val record: SkuRecord) : StorageRecord() {
-        override val id: Long = record.id
-        override val createdAt: Long = record.createdAt
+    data class SkuExport(
+        val export: SkuExportRecord
+    ) : StorageRecord() {
+        override val id: Long = export.id + 10_000
+        override val createdAt: Long = export.updatedAt
+        override val title: String = export.fileName
+        override val description: String = "${export.recordCount} SKU captures"
     }
-}
-
-// THIS IS THE FIX:
-// This function now correctly converts a List of SirimRecord objects
-// into a List of StorageRecord.Sirim objects.
-fun List<SirimRecord>.asStorageRecords(): List<StorageRecord> {
-    // For each 'SirimRecord' in the list, wrap it in a 'StorageRecord.Sirim'
-    return map { record -> StorageRecord.Sirim(record) }
-}
-
-// THIS IS THE SECOND FIX:
-// This function correctly converts a List of SkuRecord objects
-// into a List of StorageRecord.Sku objects.
-fun List<SkuRecord>.asStorageRecordsFromSku(): List<StorageRecord> {
-    // For each 'SkuRecord' in the list, wrap it in a 'StorageRecord.Sku'
-    return map { record -> StorageRecord.Sku(record) }
 }

--- a/app/src/main/java/com/sirim/scanner/data/repository/SirimRepository.kt
+++ b/app/src/main/java/com/sirim/scanner/data/repository/SirimRepository.kt
@@ -2,6 +2,7 @@ package com.sirim.scanner.data.repository
 
 import com.sirim.scanner.data.db.SirimRecord
 import com.sirim.scanner.data.db.SkuRecord
+import com.sirim.scanner.data.db.SkuExportRecord
 import com.sirim.scanner.data.db.StorageRecord
 import kotlinx.coroutines.flow.Flow
 
@@ -9,6 +10,7 @@ interface SirimRepository {
     val sirimRecords: Flow<List<SirimRecord>>
     val skuRecords: Flow<List<SkuRecord>>
     val storageRecords: Flow<List<StorageRecord>>
+    val skuExports: Flow<List<SkuExportRecord>>
 
     val records: Flow<List<SirimRecord>>
         get() = sirimRecords
@@ -27,9 +29,12 @@ interface SirimRepository {
 
     suspend fun getRecord(id: Long): SirimRecord?
     suspend fun getSkuRecord(id: Long): SkuRecord?
+    suspend fun getAllSkuRecords(): List<SkuRecord>
 
     suspend fun findBySerial(serial: String): SirimRecord?
     suspend fun findByBarcode(barcode: String): SkuRecord?
 
     suspend fun persistImage(bytes: ByteArray, extension: String = "jpg"): String
+
+    suspend fun recordSkuExport(record: SkuExportRecord): Long
 }

--- a/app/src/main/java/com/sirim/scanner/ui/screens/sku/SkuScannerScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/sku/SkuScannerScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sirim.scanner.data.ocr.BarcodeAnalyzer
 import com.sirim.scanner.data.repository.SirimRepository
+import com.sirim.scanner.data.export.ExportManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -56,12 +57,13 @@ fun SkuScannerScreen(
     onRecordSaved: (Long) -> Unit,
     repository: SirimRepository,
     analyzer: BarcodeAnalyzer,
-    appScope: CoroutineScope
+    appScope: CoroutineScope,
+    exportManager: ExportManager
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
     val viewModel: SkuScannerViewModel = viewModel(
-        factory = SkuScannerViewModel.Factory(repository, analyzer, appScope)
+        factory = SkuScannerViewModel.Factory(repository, analyzer, appScope, exportManager)
     )
 
     val captureState by viewModel.captureState.collectAsState()

--- a/app/src/main/java/com/sirim/scanner/ui/screens/storage/StorageHubScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/storage/StorageHubScreen.kt
@@ -1,0 +1,235 @@
+package com.sirim.scanner.ui.screens.storage
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sirim.scanner.R
+import com.sirim.scanner.data.db.StorageRecord
+import java.text.DateFormat
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StorageHubScreen(
+    viewModel: StorageHubViewModel,
+    isSessionValid: Boolean,
+    onRequireAuthentication: (() -> Unit) -> Unit,
+    onBack: () -> Unit,
+    onOpenSirimScanner: () -> Unit,
+    onOpenSkuScanner: () -> Unit,
+    onViewSirimRecords: () -> Unit,
+    onEditSirimRecords: () -> Unit,
+    onShareSirimRecords: () -> Unit
+) {
+    val records by viewModel.storageRecords.collectAsState()
+    val context = LocalContext.current
+    val activityLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { }
+
+    fun requireAdmin(action: () -> Unit) {
+        if (isSessionValid) {
+            action()
+        } else {
+            onRequireAuthentication(action)
+        }
+    }
+
+    fun viewExport(record: StorageRecord.SkuExport) {
+        val uri = Uri.parse(record.export.uri)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(
+                uri,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        runCatching { activityLauncher.launch(intent) }
+            .onFailure {
+                Toast.makeText(context, R.string.storage_export_view_error, Toast.LENGTH_LONG).show()
+            }
+    }
+
+    fun shareExport(record: StorageRecord.SkuExport) {
+        val uri = Uri.parse(record.export.uri)
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        activityLauncher.launch(Intent.createChooser(intent, context.getString(R.string.storage_share_export)))
+    }
+
+    fun editExport(record: StorageRecord.SkuExport) {
+        val uri = Uri.parse(record.export.uri)
+        val intent = Intent(Intent.ACTION_EDIT).apply {
+            setDataAndType(
+                uri,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        runCatching { activityLauncher.launch(intent) }
+            .onFailure {
+                Toast.makeText(context, R.string.storage_export_edit_error, Toast.LENGTH_LONG).show()
+            }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(id = R.string.storage_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = stringResource(id = R.string.cd_back)
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (records.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(text = stringResource(id = R.string.storage_empty_title), fontWeight = FontWeight.SemiBold)
+                Text(
+                    text = stringResource(id = R.string.storage_empty_message),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp)
+            ) {
+                items(records, key = { it.id }) { record ->
+                    when (record) {
+                        is StorageRecord.SirimDatabase -> {
+                            StorageHubCard(
+                                title = record.title,
+                                description = record.description,
+                                updatedAt = record.createdAt,
+                                onScanner = onOpenSirimScanner,
+                                onView = onViewSirimRecords,
+                                onShare = { requireAdmin(onShareSirimRecords) },
+                                onEdit = { requireAdmin(onEditSirimRecords) }
+                            )
+                        }
+
+                        is StorageRecord.SkuExport -> {
+                            StorageHubCard(
+                                title = stringResource(
+                                    id = R.string.storage_sku_export_title,
+                                    record.export.fileName
+                                ),
+                                description = stringResource(
+                                    id = R.string.storage_sku_export_description,
+                                    record.export.recordCount
+                                ),
+                                updatedAt = record.createdAt,
+                                onScanner = onOpenSkuScanner,
+                                onView = { viewExport(record) },
+                                onShare = { requireAdmin { shareExport(record) } },
+                                onEdit = { requireAdmin { editExport(record) } }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StorageHubCard(
+    title: String,
+    description: String,
+    updatedAt: Long,
+    onScanner: () -> Unit,
+    onView: () -> Unit,
+    onShare: () -> Unit,
+    onEdit: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = title, style = MaterialTheme.typography.titleMedium)
+                Text(text = description, style = MaterialTheme.typography.bodyMedium)
+                if (updatedAt > 0) {
+                    Text(
+                        text = "Updated ${formatTimestamp(updatedAt)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onScanner, modifier = Modifier.weight(1f)) {
+                    Text(text = stringResource(id = R.string.storage_action_scanner))
+                }
+                Button(onClick = onView, modifier = Modifier.weight(1f)) {
+                    Text(text = stringResource(id = R.string.storage_action_view))
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onShare, modifier = Modifier.weight(1f)) {
+                    Text(text = stringResource(id = R.string.storage_action_share))
+                }
+                Button(onClick = onEdit, modifier = Modifier.weight(1f)) {
+                    Text(text = stringResource(id = R.string.storage_action_edit))
+                }
+            }
+        }
+    }
+}
+
+private fun formatTimestamp(timestamp: Long): String =
+    DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(timestamp))

--- a/app/src/main/java/com/sirim/scanner/ui/screens/storage/StorageHubViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/storage/StorageHubViewModel.kt
@@ -1,0 +1,27 @@
+package com.sirim.scanner.ui.screens.storage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.sirim.scanner.data.db.StorageRecord
+import com.sirim.scanner.data.repository.SirimRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class StorageHubViewModel private constructor(
+    repository: SirimRepository
+) : ViewModel() {
+
+    val storageRecords: StateFlow<List<StorageRecord>> = repository.storageRecords
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    companion object {
+        fun Factory(repository: SirimRepository): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return StorageHubViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,17 @@
     <string name="camera_permission_required">Camera permission required</string>
     <string name="export_success">Export completed</string>
     <string name="export_failure">Export failed</string>
+    <string name="cd_back">Back</string>
+    <string name="storage_title">Storage</string>
+    <string name="storage_empty_title">No saved data yet</string>
+    <string name="storage_empty_message">Start scanning to populate your storage hub.</string>
+    <string name="storage_sku_export_title">SKU Export: %1$s</string>
+    <string name="storage_sku_export_description">%1$d captured items</string>
+    <string name="storage_action_scanner">SIRIM Scanner</string>
+    <string name="storage_action_view">View</string>
+    <string name="storage_action_share">Share</string>
+    <string name="storage_action_edit">Edit</string>
+    <string name="storage_share_export">Share SKU export</string>
+    <string name="storage_export_view_error">No compatible app found to view the export.</string>
+    <string name="storage_export_edit_error">No compatible app found to edit the export.</string>
 </resources>


### PR DESCRIPTION
## Summary
- generate and persist an Excel workbook for SKU captures after each scan, including the new sku_exports table and repository plumbing
- replace the storage screen with a secured hub that lists databases and exports with scanner, view, share, and edit actions
- add read-only navigation paths for viewing records from storage while keeping administrative edits behind authentication

## Testing
- `./gradlew :app:compileDebugJavaWithJavac --no-daemon --console=plain --quiet` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e60ff630148325b3819fd6f07d44f3