### PR TITLE
Fix missing imports for SKU scanner permission handling

### DIFF
--- a/app/src/main/java/com/sirim/scanner/ui/screens/sku/SkuScannerScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/sku/SkuScannerScreen.kt
@@ -7,6 +7,10 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis


### PR DESCRIPTION
## Summary
- add the missing activity result and settings imports required by `SkuScannerScreen`
- ensure the camera permission launcher and settings intent compile

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e60182d1008325982438ebc08869a7